### PR TITLE
Fixes to previously added functionality; bug fixes and UX enhancements

### DIFF
--- a/dist/editablegrid/columnfilterdialog/columnfilterdialog.js
+++ b/dist/editablegrid/columnfilterdialog/columnfilterdialog.js
@@ -28,17 +28,39 @@ var __read = (this && this.__read) || function (o, n) {
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { DefaultButton, Dialog, DialogFooter, Dropdown, PrimaryButton, Stack, TextField } from "office-ui-fabric-react";
 import React, { useEffect, useState } from "react";
+import { useRef } from "react";
 import { operatorsArr } from "../../types/filterstype";
 import { controlClass, dropdownStyles, modelProps, stackTokens, textFieldStyles } from "./columnfilterdialogStyles";
 var ColumnFilterDialog = function (props) {
     var _a = __read(useState(), 2), gridColumn = _a[0], setGridColumn = _a[1];
-    var _b = __read(useState(''), 2), operator = _b[0], setOperator = _b[1];
+    var _b = __read(useState(), 2), operator = _b[0], setOperator = _b[1];
     var _c = __read(useState(''), 2), value = _c[0], setValue = _c[1];
+    var operatorType = useRef('');
+    var operatorTypePrevious = useRef('');
     var onSelectGridColumn = function (event, item, index) {
-        setGridColumn(props.columnConfigurationData.filter(function (val) { return val.key == item.key; })[0]);
+        var gridColumn = props.columnConfigurationData.filter(function (val) { return val.key == item.key; })[0];
+        setGridColumn(gridColumn);
+        switch (gridColumn === null || gridColumn === void 0 ? void 0 : gridColumn.dataType) {
+            case "number":
+                doOperatorTypeChange("number");
+                break;
+            case "string":
+                doOperatorTypeChange("string");
+                break;
+            case "date":
+                doOperatorTypeChange("date");
+                break;
+        }
+        if (operatorType.current !== operatorTypePrevious.current) {
+            setOperator(undefined);
+        }
+    };
+    var doOperatorTypeChange = function (dataType) {
+        operatorTypePrevious.current = operatorType.current;
+        operatorType.current = dataType;
     };
     var onSelectOperator = function (event, item, index) {
-        setOperator(item.text.toString());
+        setOperator(item);
     };
     var onSelectValue = function (event, item, index) {
         setValue(item.key.toString());
@@ -54,20 +76,20 @@ var ColumnFilterDialog = function (props) {
                 switch (column[0].dataType) {
                     case 'number':
                         setInputFieldContent(_jsx(TextField, { className: controlClass.textFieldClass, placeholder: "Value", onChange: function (ev, text) { return onTextUpdate(ev, text); }, styles: textFieldStyles }, void 0));
-                        setOperatorDropDownContent(_jsx(Dropdown, { placeholder: "Select Operator", options: createCompareOptions(), styles: dropdownStyles, onChange: onSelectOperator }, void 0));
+                        setOperatorDropDownContent(_jsx(Dropdown, { placeholder: "Select Operator", options: createCompareOptions(), styles: dropdownStyles, onChange: onSelectOperator, selectedKey: operator ? operator.key : null }, void 0));
                         break;
                     case 'string':
                         setInputFieldContent(_jsx(TextField, { className: controlClass.textFieldClass, placeholder: "Value", onChange: function (ev, text) { return onTextUpdate(ev, text); }, styles: textFieldStyles }, void 0));
-                        setOperatorDropDownContent(_jsx(Dropdown, { placeholder: "Select Operator", options: createCompareOptions(), styles: dropdownStyles, onChange: onSelectOperator }, void 0));
+                        setOperatorDropDownContent(_jsx(Dropdown, { placeholder: "Select Operator", options: createCompareOptions(), styles: dropdownStyles, onChange: onSelectOperator, selectedKey: operator ? operator.key : null }, void 0));
                         break;
                     case 'date':
                         setInputFieldContent(_jsx(Dropdown, { placeholder: "Select the Column", options: valueOptions, styles: dropdownStyles, onChange: onSelectValue }, void 0));
-                        setOperatorDropDownContent(_jsx(Dropdown, { placeholder: "Select Operator", options: createCompareOptions(), styles: dropdownStyles, onChange: onSelectOperator }, void 0));
+                        setOperatorDropDownContent(_jsx(Dropdown, { placeholder: "Select Operator", options: createCompareOptions(), styles: dropdownStyles, onChange: onSelectOperator, selectedKey: operator ? operator.key : null }, void 0));
                         break;
                 }
             }
         }
-    }, [gridColumn]);
+    }, [gridColumn, operator]);
     var createDropDownOptions = function () {
         var dropdownOptions = [];
         props.columnConfigurationData.forEach(function (item, index) {
@@ -106,7 +128,7 @@ var ColumnFilterDialog = function (props) {
     };
     //const compareOptions = createCompareOptions();
     var _d = __read(React.useState(_jsx(Dropdown, { placeholder: "Select the Column", options: options, styles: dropdownStyles, onChange: onSelectValue }, void 0)), 2), inputFieldContent = _d[0], setInputFieldContent = _d[1];
-    var _e = __read(React.useState(_jsx(Dropdown, { placeholder: "Select Operator", disabled: true, options: createCompareOptions(), styles: dropdownStyles, onChange: onSelectValue }, void 0)), 2), operatorDropDownContent = _e[0], setOperatorDropDownContent = _e[1];
+    var _e = __read(React.useState(_jsx(Dropdown, { placeholder: "Select Operator", disabled: true, options: createCompareOptions(), styles: dropdownStyles, onChange: onSelectOperator }, void 0)), 2), operatorDropDownContent = _e[0], setOperatorDropDownContent = _e[1];
     var closeDialog = React.useCallback(function () {
         if (props.onDialogCancel) {
             props.onDialogCancel();
@@ -114,7 +136,7 @@ var ColumnFilterDialog = function (props) {
         setInputFieldContent(undefined);
     }, []);
     var saveDialog = function () {
-        var filterObj = { column: gridColumn, operator: operator, value: value };
+        var filterObj = { column: gridColumn, operator: operator ? operator.text.toString() : '', value: value };
         if (props.onDialogSave) {
             props.onDialogSave(filterObj);
         }
@@ -124,6 +146,6 @@ var ColumnFilterDialog = function (props) {
                         // eslint-disable-next-line react/jsx-no-bind
                         , { 
                             // eslint-disable-next-line react/jsx-no-bind
-                            onClick: saveDialog, text: "Save" }, void 0), _jsx(DefaultButton, { onClick: closeDialog, text: "Cancel" }, void 0)] }), void 0) }, void 0)] }), void 0));
+                            onClick: saveDialog, text: "Save", disabled: gridColumn === undefined || value === '' }, void 0), _jsx(DefaultButton, { onClick: closeDialog, text: "Cancel" }, void 0)] }), void 0) }, void 0)] }), void 0));
 };
 export default ColumnFilterDialog;

--- a/dist/editablegrid/editablegrid.js
+++ b/dist/editablegrid/editablegrid.js
@@ -134,6 +134,8 @@ var EditableGrid = function (props) {
     }), 2), messageDialogProps = _2[0], setMessageDialogProps = _2[1];
     var _3 = __read(React.useState({ key: '', isAscending: false, isEnabled: false }), 2), sortColObj = _3[0], setSortColObj = _3[1];
     var _4 = __read(React.useState(false), 2), hasRenderedStickyContent = _4[0], setHasRenderedStickyContent = _4[1];
+    var _5 = __read(React.useState(), 2), aboveContentHeight = _5[0], setAboveContentHeight = _5[1];
+    var _6 = __read(React.useState(), 2), belowContentHeight = _6[0], setBelowContentHeight = _6[1];
     var SpinRef = React.createRef();
     var filterStoreRef = React.useRef([]);
     var _selection = new Selection({
@@ -339,6 +341,7 @@ var EditableGrid = function (props) {
         CloseColumnUpdateDialog();
         defaultGridDataTmp = CheckBulkUpdateOnChangeCallBack(data, defaultGridDataTmp);
         SetGridItems(defaultGridDataTmp);
+        UpdateSelectedItems(defaultGridDataTmp);
     };
     var CloseColumnUpdateDialog = function () {
         setIsUpdateColumnClicked(false);
@@ -803,10 +806,20 @@ var EditableGrid = function (props) {
         }
         return true;
     };
+    var UpdateSelectedItems = function (items) {
+        if (selectedIndices.length) {
+            var itemsSelected_1 = [];
+            setSelectedItems(selectedIndices.map(function (index) {
+                itemsSelected_1.push(items[index]);
+            }));
+            setSelectedItems(itemsSelected_1);
+        }
+    };
     var ResetGridData = function () {
         setGridEditState(false);
         ClearFilters();
         SetGridItems(backupDefaultGridData.map(function (obj) { return (__assign({}, obj)); }));
+        UpdateSelectedItems(backupDefaultGridData);
     };
     /* #region [Column Click] */
     var onColumnClick = function (ev, column, index) {
@@ -1204,8 +1217,8 @@ var EditableGrid = function (props) {
             commandBarItems.push({
                 id: 'submit',
                 key: 'submit',
-                text: "Save to SharePoint",
-                ariaLabel: 'Save to SharePoint',
+                text: props.enableSaveText ? props.enableSaveText : "Submit",
+                ariaLabel: props.enableSaveText ? props.enableSaveText : "Submit",
                 disabled: isGridInEdit || !isGridStateEdited,
                 iconProps: { iconName: 'Save' },
                 onClick: function () { return onGridSave(); },
@@ -1404,9 +1417,11 @@ var EditableGrid = function (props) {
             if (sticky) {
                 if (props.aboveStickyContent) {
                     scrollablePaneRef.current._addToStickyContainer(sticky, scrollablePaneRef.current._stickyAboveRef.current, props.aboveStickyContent);
+                    setAboveContentHeight(props.aboveStickyContent.offsetHeight);
                 }
                 if (props.belowStickyContent) {
                     scrollablePaneRef.current._addToStickyContainer(sticky, scrollablePaneRef.current._stickyBelowRef.current, props.belowStickyContent);
+                    setBelowContentHeight(props.belowStickyContent.offsetHeight);
                 }
                 setHasRenderedStickyContent(true);
             }
@@ -1420,7 +1435,7 @@ var EditableGrid = function (props) {
                 _jsx(TagPicker, { onResolveSuggestions: onFilterChanged, getTextFromItem: getTextFromItem, pickerSuggestionsProps: pickerSuggestionsProps, inputProps: inputProps, selectedItems: defaultTag, onChange: onFilterTagListChanged }, void 0) : null, props.enableCommandBar === undefined || props.enableCommandBar === true ? _jsx(CommandBar, { items: CommandBarItemProps, ariaLabel: "Command Bar", farItems: CommandBarFarItemProps }, void 0) : null, showSpinner ?
                 _jsx(Spinner, { label: "Updating...", ariaLive: "assertive", labelPosition: "right", size: SpinnerSize.large }, void 0)
                 :
-                    null, showFilterCallout && filterCalloutComponent, _jsx("div", __assign({ className: mergeStyles({ height: props.height != null ? props.height : '70vh', width: props.width != null ? props.width : '130vh', position: 'relative', backgroundColor: 'white', }) }, { children: _jsx(ScrollablePane, __assign({ componentRef: scrollablePaneRef, scrollbarVisibility: ScrollbarVisibility.auto }, { children: _jsx(MarqueeSelection, __assign({ selection: _selection, isEnabled: props.enableMarqueeSelection !== undefined ? props.enableMarqueeSelection : true }, { children: _jsx(DetailsList, { compact: true, items: defaultGridData.length > 0 ? defaultGridData.filter(function (x) { return (x._grid_row_operation_ != Operation.Delete) && (x._is_filtered_in_ == true) && (x._is_filtered_in_grid_search_ == true) && (x._is_filtered_in_column_filter_ == true); }) : [], columns: GridColumns, selectionMode: props.selectionMode, 
+                    null, showFilterCallout && filterCalloutComponent, _jsx("div", __assign({ className: mergeStyles({ height: props.height != null ? props.height : '70vh', width: props.width != null ? props.width : '130vh', position: 'relative', backgroundColor: 'white', }) }, { children: _jsx(ScrollablePane, __assign({ styles: { contentContainer: { paddingTop: aboveContentHeight, paddingBottom: belowContentHeight } }, componentRef: scrollablePaneRef, scrollbarVisibility: ScrollbarVisibility.auto }, { children: _jsx(MarqueeSelection, __assign({ selection: _selection, isEnabled: props.enableMarqueeSelection !== undefined ? props.enableMarqueeSelection : true }, { children: _jsx(DetailsList, { compact: true, items: defaultGridData.length > 0 ? defaultGridData.filter(function (x) { return (x._grid_row_operation_ != Operation.Delete) && (x._is_filtered_in_ == true) && (x._is_filtered_in_grid_search_ == true) && (x._is_filtered_in_column_filter_ == true); }) : [], columns: GridColumns, selectionMode: props.selectionMode, 
                             // layoutMode={props.layoutMode}
                             // constrainMode={props.constrainMode}
                             layoutMode: DetailsListLayoutMode.fixedColumns, constrainMode: ConstrainMode.unconstrained, selection: _selection, setKey: "none", onRenderDetailsHeader: onRenderDetailsHeader, ariaLabelForSelectAllCheckbox: "Toggle selection for all items", ariaLabelForSelectionColumn: "Toggle selection", checkButtonAriaLabel: "Row checkbox", ariaLabel: props.ariaLabel, ariaLabelForGrid: props.ariaLabelForGrid, ariaLabelForListHeader: props.ariaLabelForListHeader, cellStyleProps: props.cellStyleProps, checkboxCellClassName: props.checkboxCellClassName, checkboxVisibility: props.checkboxVisibility, className: props.className, columnReorderOptions: props.columnReorderOptions, componentRef: props.componentRef, disableSelectionZone: props.disableSelectionZone, dragDropEvents: props.dragDropEvents, enableUpdateAnimations: props.enableUpdateAnimations, enterModalSelectionOnTouch: props.enterModalSelectionOnTouch, getCellValueKey: props.getCellValueKey, getGroupHeight: props.getGroupHeight, getKey: props.getKey, getRowAriaDescribedBy: props.getRowAriaDescribedBy, getRowAriaLabel: props.getRowAriaLabel, groupProps: props.groupProps, groups: props.groups, indentWidth: props.indentWidth, initialFocusedIndex: props.initialFocusedIndex, isHeaderVisible: props.isHeaderVisible, isPlaceholderData: props.isPlaceholderData, listProps: props.listProps, minimumPixelsForDrag: props.minimumPixelsForDrag, onActiveItemChanged: props.onActiveItemChanged, onColumnHeaderClick: props.onColumnHeaderClick, onColumnHeaderContextMenu: props.onColumnHeaderContextMenu, onColumnResize: props.onColumnResize, onDidUpdate: props.onDidUpdate, onItemContextMenu: props.onItemContextMenu, onItemInvoked: props.onItemInvoked, onRenderCheckbox: props.onRenderCheckbox, onRenderDetailsFooter: props.onRenderDetailsFooter, onRenderItemColumn: props.onRenderItemColumn, onRenderMissingItem: props.onRenderMissingItem, onRenderRow: props.onRenderRow, onRowDidMount: props.onRowDidMount, onRowWillUnmount: props.onRowWillUnmount, onShouldVirtualize: props.onShouldVirtualize, rowElementEventMap: props.rowElementEventMap, selectionPreservedOnEmptyClick: props.selectionPreservedOnEmptyClick, selectionZoneProps: props.selectionZoneProps, shouldApplyApplicationRole: props.shouldApplyApplicationRole, styles: props.styles, useFastIcons: props.useFastIcons, usePageCache: props.usePageCache, useReducedRowRenderer: props.useReducedRowRenderer, viewport: props.viewport }, void 0) }), void 0) }), void 0) }), void 0), _jsx(Dialog, __assign({ hidden: !dialogContent, onDismiss: CloseRenameDialog, closeButtonAriaLabel: "Close" }, { children: dialogContent }), void 0), messageDialogProps.visible

--- a/dist/editablegrid/helper.js
+++ b/dist/editablegrid/helper.js
@@ -72,7 +72,10 @@ export var IsValidDataType = function (type, text) {
     var isValid = true;
     switch (type) {
         case 'number':
-            isValid = !isNaN(Number(text));
+            var regex = new RegExp(/^\d*(\.\d{0,2})?$/, 'g');
+            if (!regex.test(text)) {
+                isValid = false;
+            }
             break;
     }
     return isValid;
@@ -105,7 +108,7 @@ export var ParseType = function (type, text) {
     }
     switch (type) {
         case 'number':
-            return Number(text);
+            return text;
         case 'date':
             return Date.parse(text);
     }

--- a/dist/types/editabledetailslistprops.d.ts
+++ b/dist/types/editabledetailslistprops.d.ts
@@ -11,6 +11,7 @@ export interface Props extends IDetailsListProps {
     enableExport?: boolean;
     exportFileName?: string;
     enableSave?: boolean;
+    enableSaveText?: string;
     enableRowEdit?: boolean;
     prependRowEditActions?: boolean;
     enableRowEditCancel?: boolean;

--- a/src/Examples/gridconsumer/gridconfig.tsx
+++ b/src/Examples/gridconsumer/gridconfig.tsx
@@ -89,7 +89,6 @@ export const GridColumnConfig: IColumnConfig[] =
             isResizable: true,
             includeColumnInExport: false,
             includeColumnInSearch: true,
-            maxLength: 5,
             applyColumnFilter: true,
             cellStyleRule: {
                 enable: true,

--- a/src/Examples/gridconsumer/gridconsumer.tsx
+++ b/src/Examples/gridconsumer/gridconsumer.tsx
@@ -353,6 +353,7 @@ const Consumer = () => {
                 id={1}
                 enableColumnEdit={gridConfigOptions.enableColumnEdit}
                 enableSave={gridConfigOptions.enableSave}
+                //enableSaveText="Save to List"
                 columns={attachGridValueChangeCallbacks(GridColumnConfig)}
                 //customEditPanelColumns={GridColumnConfigCustomPanelEdit}
                 layoutMode={DetailsListLayoutMode.justified}

--- a/src/libs/editablegrid/editablegrid.tsx
+++ b/src/libs/editablegrid/editablegrid.tsx
@@ -89,6 +89,8 @@ const EditableGrid = (props: Props) => {
     });
     const [sortColObj, setSortColObj] = React.useState<SortOptions>({ key: '', isAscending: false, isEnabled: false });
     const [hasRenderedStickyContent, setHasRenderedStickyContent] = React.useState<boolean>(false);
+    const [aboveContentHeight, setAboveContentHeight] = React.useState<number>();
+    const [belowContentHeight, setBelowContentHeight] = React.useState<number>();
     let SpinRef: any = React.createRef();
     let filterStoreRef: any = React.useRef<IFilter[]>([]);
 
@@ -314,6 +316,7 @@ const EditableGrid = (props: Props) => {
 
         defaultGridDataTmp = CheckBulkUpdateOnChangeCallBack(data, defaultGridDataTmp);
         SetGridItems(defaultGridDataTmp);
+        UpdateSelectedItems(defaultGridDataTmp);
     }
 
     const CloseColumnUpdateDialog = (): void => {
@@ -858,7 +861,6 @@ const EditableGrid = (props: Props) => {
                 }
                 break;
             case EditType.ColumnEdit:
-
                 if (selectedIndices.length > 0) {
                     ShowColumnUpdate();
                 }
@@ -890,11 +892,23 @@ const EditableGrid = (props: Props) => {
         return true;
     }
 
-    const ResetGridData = (): void => {
+    const UpdateSelectedItems = (items: Array<any>): void => {
+        if (selectedIndices.length) {
+            let itemsSelected: Array<any> = [];
 
+            setSelectedItems(selectedIndices.map((index) => {
+                itemsSelected.push(items[index]);
+            }));
+
+            setSelectedItems(itemsSelected);
+        }
+    }
+
+    const ResetGridData = (): void => {
         setGridEditState(false);
         ClearFilters();
         SetGridItems(backupDefaultGridData.map(obj => ({ ...obj })));
+        UpdateSelectedItems(backupDefaultGridData);
     };
 
     /* #region [Column Click] */
@@ -1464,8 +1478,8 @@ const EditableGrid = (props: Props) => {
             commandBarItems.push({
                 id: 'submit',
                 key: 'submit',
-                text: "Save to SharePoint",
-                ariaLabel: 'Save to SharePoint',
+                text: props.enableSaveText ? props.enableSaveText : "Submit",
+                ariaLabel: props.enableSaveText ? props.enableSaveText : "Submit",
                 disabled: isGridInEdit || !isGridStateEdited,
                 iconProps: { iconName: 'Save' },
                 onClick: () => onGridSave(),
@@ -1735,10 +1749,12 @@ const EditableGrid = (props: Props) => {
             if (sticky) {
                 if (props.aboveStickyContent) {
                     scrollablePaneRef.current._addToStickyContainer(sticky, scrollablePaneRef.current._stickyAboveRef.current, props.aboveStickyContent);
+                    setAboveContentHeight(props.aboveStickyContent.offsetHeight);
                 }
 
                 if (props.belowStickyContent) {
                     scrollablePaneRef.current._addToStickyContainer(sticky, scrollablePaneRef.current._stickyBelowRef.current, props.belowStickyContent);
+                    setBelowContentHeight(props.belowStickyContent.offsetHeight);
                 }
 
                 setHasRenderedStickyContent(true);
@@ -1808,7 +1824,7 @@ const EditableGrid = (props: Props) => {
 
             {showFilterCallout && filterCalloutComponent}
             <div className={mergeStyles({ height: props.height != null ? props.height : '70vh', width: props.width != null ? props.width : '130vh', position: 'relative', backgroundColor: 'white', })}>
-                <ScrollablePane componentRef={scrollablePaneRef} scrollbarVisibility={ScrollbarVisibility.auto}>
+                <ScrollablePane styles={{ contentContainer: { paddingTop: aboveContentHeight, paddingBottom: belowContentHeight } }} componentRef={scrollablePaneRef} scrollbarVisibility={ScrollbarVisibility.auto}>
                     <MarqueeSelection selection={_selection} isEnabled={props.enableMarqueeSelection !== undefined ? props.enableMarqueeSelection : true} >
                         <DetailsList
                             compact={true}

--- a/src/libs/editablegrid/helper.tsx
+++ b/src/libs/editablegrid/helper.tsx
@@ -62,7 +62,10 @@ export const IsValidDataType = (type: string | undefined, text: string): boolean
     var isValid = true;
     switch (type) {
         case 'number':
-            isValid = !isNaN(Number(text));
+            var regex = new RegExp(/^\d*(\.\d{0,2})?$/, 'g');
+            if (!regex.test(text)) {
+                isValid = false;
+            }
             break;
     }
 
@@ -103,7 +106,7 @@ export const ParseType = (type: string | undefined, text: string): any => {
 
     switch (type) {
         case 'number':
-            return Number(text);
+            return text;
         case 'date':
             return Date.parse(text);
     }

--- a/src/libs/types/editabledetailslistprops.tsx
+++ b/src/libs/types/editabledetailslistprops.tsx
@@ -12,6 +12,7 @@ export interface Props extends IDetailsListProps {
     enableExport?: boolean;
     exportFileName?: string;
     enableSave?: boolean;
+    enableSaveText?: string;
     enableRowEdit?: boolean;
     prependRowEditActions?: boolean;
     enableRowEditCancel?: boolean;


### PR DESCRIPTION
Above/Below content now properly apply padding to ScrollablePane.

Reset Data now properly updates currently selected item with changes.

"Number" type input allows up to 2 decimals.

Filter panel filter button disabled until all inputs are filled to prevent null exception.

Filter panel now correctly changes operators when switching between columns.

"EnableSaveText" prop added to EditableGrid which allows customisation of the "Submit" button text and arial-label.